### PR TITLE
Allow XCreateWindow to use CopyFromParent

### DIFF
--- a/source/x11/Xlib.d
+++ b/source/x11/Xlib.d
@@ -1545,6 +1545,18 @@ extern Window XCreateWindow(
     c_ulong                                             /* valuemask                                                    */,
     XSetWindowAttributes*                               /* attributes                                                   */
 );
+/++
+ + Create windows and window attributes structure.
+ +
+ + This overload allow you to pass the special parameter "CopyFromParent".
+ + Watch out as it will accept any kind of XID, hence it is not type safe.
+ +/
+extern Window XCreateWindow(Display* display, Window   parent,
+                            int x, int y, uint width, uint height,
+                            uint border_width, int depth, uint _class,
+                            XID copyFromParent, c_ulong  valuemask,
+                            XSetWindowAttributes* attributes);
+
 extern Colormap* XListInstalledColormaps(
     Display*                                            /* display                                                      */,
     Window                                              /* w                                                            */,


### PR DESCRIPTION
Hi,
While porting some code from C to D, I hit an issue of this line of code:

```
win = XCreateWindow(data.display, p_desktop, 0, 0,
                                cast(int)xsh.width, cast(int)xsh.height,
                                0,
                                CopyFromParent, InputOutput, CopyFromParent,
                                CWOverrideRedirect, &attr);
```

Result:

```
source/app.d(175): Error: function x11.Xlib.XCreateWindow (_XDisplay*, ulong, int, int, uint, uint, uint, int, uint, Visual*, ulong, XSetWindowAttributes*) is not callable using argument types (_XDisplay*, ulong, int, int, int, int, int, const(ulong), int, const(ulong), int, XSetWindowAttributes*)

```

(Look the 10th argument, or 3rd from the end: Display\* vs const(ulong)).

After a bit of research, I found the following code in X.h (line 114):

```
#ifndef None
#define None                 0L /* universal null resource or null atom */
#endif

#define ParentRelative       1L /* background pixmap in CreateWindow                                                                                                            
                                    and ChangeWindowAttributes */

#define CopyFromParent       0L /* border pixmap in CreateWindow                                                                                                                
                                       and ChangeWindowAttributes                                                                                                               
                                   special VisualID and special window                                                                                                          
                                       class passed to CreateWindow */

#define PointerWindow        0L /* destination window in SendEvent */
#define InputFocus           1L /* destination window in SendEvent */

#define PointerRoot          1L /* focus window in SetInputFocus */

[...]
```

Which gets translated into:

```
const XID       None            = 0;    /* universal null resource or null atom                                             */
const XID       ParentRelative  = 1;    /* background pixmap in CreateWindow and ChangeWindowAttributes                     */
const XID       CopyFromParent  = 0;    /* border pixmap in CreateWindow and ChangeWindowAttributes special VisualID and                                                        
                                       special window class passed to CreateWindow                                      */

const Window    PointerWindow   = 0;    /* destination window in SendEvent                                              */
const Window    InputFocus      = 1;    /* destination window in SendEvent                                              */
const Window    PointerRoot     = 1;    /* focus window in SetInputFocus                                                */

[...]
```

So the problem is: XCreateWindow accept a 'Visual*' as it's 10th arg, but this can also be a XID (c_ulong), which has a special meaning. But in order, this XID can be either a 'Pixmap' or a 'Visual' (see the comment).

1) Adding another symbol with the same name is obviously not possible.
2) Changing the type to a pointer would have to make it either Pixmap\* or Visual*.
3) Changing XID to be pointers is not possible either.

Hence, the best solution I found so far is to add an overload and to document it. It is a bit different from the rest of the file, because having a documentation comment and parameters name would help a lot people using IDE.

Note: I didn't update ChangeWindowAttributes as I'm not using it right now, and thus won't be able to test it.
