### PR TITLE
remove duplicated alias

### DIFF
--- a/source/x11/Xmd.d
+++ b/source/x11/Xmd.d
@@ -53,7 +53,6 @@ alias _SIZEOF SIZEOF;
  */
 version( X86_64 ){
     alias long INT64;
-    alias c_ulong CARD64;
     //~ #  define B32 :32
     //~ #  define B16 :16
     alias uint INT32;


### PR DESCRIPTION
CARD64 will always be declared later, also see [Issue 15167 – [REG2.069-devel] conflicting error with repeated alias declaration](https://issues.dlang.org/show_bug.cgi?id=15167).